### PR TITLE
Add new tag for testing

### DIFF
--- a/Bricks/_MasonTest1/0.2.0.toml
+++ b/Bricks/_MasonTest1/0.2.0.toml
@@ -1,0 +1,8 @@
+
+[brick]
+name = "_MasonTest1"
+version = "0.2.0"
+author = "Sam Partee"
+source = "https://github.com/Spartee/_MasonTest1"
+
+[dependencies]


### PR DESCRIPTION
Adds a toml file for _MasonTest1-v0.2.0. This will be one of many such commits to come to beef up the testing for mason. 