### PR TITLE
Add upper bound to LinearAlgebraJama and MatrixMarket

### DIFF
--- a/Bricks/LinearAlgebraJama/0.1.0.toml
+++ b/Bricks/LinearAlgebraJama/0.1.0.toml
@@ -2,7 +2,7 @@
 [brick]
 name = "LinearAlgebraJama"
 version = "0.1.0"
-chplVersion = "1.16.0"
+chplVersion = "1.16.0..1.18.0"
 author = "ct-clmsn"
 source = "https://github.com/ct-clmsn/LinearAlgebraJama"
 

--- a/Bricks/MatrixMarket/0.1.0.toml
+++ b/Bricks/MatrixMarket/0.1.0.toml
@@ -2,7 +2,7 @@
 [brick]
 name = "MatrixMarket"
 version = "0.1.0"
-chplVersion = "1.16.0"
+chplVersion = "1.16.0..1.18.0"
 author = "ct-clmsn"
 source = "https://github.com/ct-clmsn/MatrixMarket"
 


### PR DESCRIPTION
LinearAlgebraJama and MatrixMarket no longer work for Chapel 1.19 as reported in https://github.com/chapel-lang/chapel/issues/12760.