### PR TITLE
Shift from Travis CI to Github Actions

### DIFF
--- a/.github/workflows/genCacheOnPush.yaml
+++ b/.github/workflows/genCacheOnPush.yaml
@@ -1,0 +1,40 @@
+name: Generate Rank on Cache
+on: 
+  push: 
+    branch:
+      - master
+    path:
+      - 'Bricks/**'
+    paths-ignore:
+      - '.github/**'
+      - 'util/**'
+jobs:
+  run_on_push:
+    name: Append Rank to Cache
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 4
+      - name: Run script to rank packages
+        run: |
+          bash ./util/searchRankScript.bash
+      - name: setup python 3.7
+        uses: actions/setup-python@v1
+        with: 
+          python-version: "3.7"
+      - name: Sort cache file
+        run: |
+          pip install toml-sort
+          toml-sort cache.toml -o cache.toml
+          cat cache.toml
+      - name: Commit changes
+        run: |
+          git config --global user.name "ankingcodes"
+          git config --global user.name "ankush.bhardwaj0@gmail.com"
+          git add cache.toml
+          git commit -m "appended to cache.toml"
+      - name: Append rank to Cache
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/genCacheOnPush.yaml.disabled
+++ b/.github/workflows/genCacheOnPush.yaml.disabled
@@ -1,6 +1,8 @@
 name: Generate Rank on Cache
 on: 
   push: 
+    branches-ignore: # disables this script for now
+      - '**' 
     branch:
       - master
     path:
@@ -25,15 +27,17 @@ jobs:
           python-version: "3.7"
       - name: Sort cache file
         run: |
-          pip install toml-sort
+          python3 -m pip install toml-sort==0.17.0
           toml-sort cache.toml -o cache.toml
           cat cache.toml
       - name: Commit changes
         run: |
-          git config --global user.name "ankingcodes"
-          git config --global user.name "ankush.bhardwaj0@gmail.com"
+          # WIP: use authentic credentials
+          git config --global user.name "chapel"
+          git config --global user.name "chapel@gmail.com"
           git add cache.toml
-          git commit -m "appended to cache.toml"
+          commit_sha=$(git rev-parse HEAD | cut -c 1-8)
+          git commit -m "appended package from $commit_sha to cache.toml"
       - name: Append rank to Cache
         uses: ad-m/github-push-action@master
         with:

--- a/.github/workflows/masonRegCI.yaml
+++ b/.github/workflows/masonRegCI.yaml
@@ -1,0 +1,20 @@
+name: Mason Registry CI
+on:
+  pull_request: 
+    paths:
+      - 'Bricks/**'
+jobs:
+  checks_for_package:
+    name: Check Package 
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 3
+      - name: Run checkTomlScript
+        run: |
+          bash ./checkTomls.bash
+      - name: CI Check package
+        run: |
+          bash ./util/travisScript.bash
+

--- a/util/searchRankScript.bash
+++ b/util/searchRankScript.bash
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Clone the package to be published from latest commit
+package=$(git diff --name-only HEAD HEAD~1)
+end=".end"
+
+# check for TOML file
+if [[ $package != *".toml"* ]]; then
+  echo "Not TOML FILE"
+  exit 0
+fi
+path="$package$end"
+cd "$(dirname "$path")" || exit 1
+FILE=$package
+basename "$FILE"
+f="$(basename -- "$FILE")"
+source="$(grep source "$f"| cut -d= -f2)"
+fixed=$(echo "$source" | tr -d '"')
+name="$(grep name "$f" | cut -d= -f2 | tr -d '"' | tr -d ' ')"
+version="$(grep version "$f" | cut -d= -f2 | tr -d '"' | tr -d ' ')"
+git clone "$fixed" newPackage
+cd newPackage || exit 1
+
+# Perform a series of check on the package and award points
+mason=./Mason.toml
+testDir=./test/
+exampleDir=./example/
+srcDir=./src/
+score=0
+countForREADME=$(ls -l ./README.* 2>/dev/null | wc -l)
+if [ "$countForREADME" != 0 ]
+then
+  echo "README found"
+  score=$((score+1))
+fi
+countForModuleFile=$(ls -l ./src/*.chpl 2>/dev/null | wc -l)
+if [ "$countForModuleFile" != 0 ]
+then
+  echo "ModuleFile found"
+  score=$((score+1))
+fi
+[[ -f "$mason" ]] && score=$((score+1)) && echo "Mason.toml found"
+[[ -d "$testDir" ]] && score=$((score+1)) && echo "test dir found"
+[[ -d "$exampleDir" ]] && score=$((score+1)) && echo "example dir found"
+[[ -d "$srcDir" ]] && score=$((score+1)) && echo "src dir found"
+
+# points for number of examples 
+countForExamples=$(ls -l ./example/*.chpl 2>/dev/null | wc -l)
+score=$((score+countForExamples))
+
+# points for number of tests
+countForTests=$(ls -l ./test/*.chpl 2>/dev/null | wc -l)
+score=$((score+countForTests))
+echo "$score"
+
+cd ../../../ || exit 1
+
+# check if package name and version already exists 
+if grep "$name.\"$version\"" cache.toml
+then 
+  echo "Package already exists. Cannot overwrite."
+  exit 1
+fi
+
+# append package score to TOML cache file
+echo "[$name.\"$version\"]" >> cache.toml
+echo "score = $score" >> cache.toml
+echo "Wrote $name=$score to cache.toml"
+

--- a/util/searchRankScript.bash
+++ b/util/searchRankScript.bash
@@ -1,58 +1,63 @@
 #!/usr/bin/env bash
 # Clone the package to be published from latest commit
 package=$(git diff --name-only HEAD HEAD~1)
-end=".end"
+echo "[LOG]: Package path from git command = ${package}"
 
 # check for TOML file
-if [[ $package != *".toml"* ]]; then
+if [[ $(basename -- $package) != *".toml"* ]]; then
   echo "Not TOML FILE"
   exit 0
 fi
-path="$package$end"
-cd "$(dirname "$path")" || exit 1
+
+path="$package"
+echo "[LOG]: path = $(dirname ${path})"
 FILE=$package
-basename "$FILE"
 f="$(basename -- "$FILE")"
-source="$(grep source "$f"| cut -d= -f2)"
-fixed=$(echo "$source" | tr -d '"')
-name="$(grep name "$f" | cut -d= -f2 | tr -d '"' | tr -d ' ')"
-version="$(grep version "$f" | cut -d= -f2 | tr -d '"' | tr -d ' ')"
-git clone "$fixed" newPackage
-cd newPackage || exit 1
+echo "[LOG]: Package TOML file = ${f}"
+source="$(grep source "$path"| cut -d= -f2)"
+fixed=$(echo "$source" 2> /dev/null | tr -d '"')
+echo "[LOG]: Package url = ${fixed}"
+name="$(grep name "$path" | cut -d= -f2 | tr -d '"' | tr -d ' ')"
+echo "[LOG]: Package name = ${name}"
+version="$(grep version "$path" | cut -d= -f2 | tr -d '"' | tr -d ' ')"
+echo "[LOG]: Version = ${version}"
+git clone "$fixed" "$(dirname ${path})/newPackage"
+packagePath="$(dirname ${path})/newPackage"
+echo "$name cloned succesfully at $packagePath"
 
 # Perform a series of check on the package and award points
-mason=./Mason.toml
-testDir=./test/
-exampleDir=./example/
-srcDir=./src/
+mason=$packagePath/Mason.toml
+testDir=$packagePath/test/
+exampleDir=$packagePath/example/
+srcDir=$packagePath/src/
 score=0
-countForREADME=$(ls -l ./README.* 2>/dev/null | wc -l)
+countForREADME=$(ls -l $packagePath/README.* 2>/dev/null | wc -l)
 if [ "$countForREADME" != 0 ]
 then
-  echo "README found"
+  echo "README found in package"
   score=$((score+1))
 fi
-countForModuleFile=$(ls -l ./src/*.chpl 2>/dev/null | wc -l)
+countForModuleFile=$(ls -l $packagePath/src/*.chpl 2>/dev/null | wc -l)
 if [ "$countForModuleFile" != 0 ]
 then
-  echo "ModuleFile found"
+  echo "ModuleFile found in package"
   score=$((score+1))
 fi
-[[ -f "$mason" ]] && score=$((score+1)) && echo "Mason.toml found"
-[[ -d "$testDir" ]] && score=$((score+1)) && echo "test dir found"
-[[ -d "$exampleDir" ]] && score=$((score+1)) && echo "example dir found"
-[[ -d "$srcDir" ]] && score=$((score+1)) && echo "src dir found"
+[[ -f "$mason" ]] && score=$((score+1)) && echo "Mason.toml found in package"
+[[ -d "$testDir" ]] && score=$((score+1)) && echo "test dir found in package"
+[[ -d "$exampleDir" ]] && score=$((score+1)) && echo "example dir found in package"
+[[ -d "$srcDir" ]] && score=$((score+1)) && echo "src dir found in package"
 
 # points for number of examples 
-countForExamples=$(ls -l ./example/*.chpl 2>/dev/null | wc -l)
+countForExamples=$(ls -l $exampleDir/*.chpl 2>/dev/null | wc -l)
+echo "Found $countForExamples examples in package."
 score=$((score+countForExamples))
 
 # points for number of tests
-countForTests=$(ls -l ./test/*.chpl 2>/dev/null | wc -l)
+countForTests=$(ls -l $testDir/*.chpl 2>/dev/null | wc -l)
+echo "Found $countForTests tests in package."
 score=$((score+countForTests))
-echo "$score"
-
-cd ../../../ || exit 1
+echo "Total score generated for $name = $score"
 
 # check if package name and version already exists 
 if grep "$name.\"$version\"" cache.toml
@@ -64,5 +69,5 @@ fi
 # append package score to TOML cache file
 echo "[$name.\"$version\"]" >> cache.toml
 echo "score = $score" >> cache.toml
-echo "Wrote $name=$score to cache.toml"
+echo "Wrote '$name = $score' to cache.toml"
 

--- a/util/travisScript.bash
+++ b/util/travisScript.bash
@@ -4,7 +4,7 @@
 git clone --depth=1 --branch=master https://github.com/chapel-lang/chapel.git
 
 buildChapel () {
-  cd chapel
+  cd chapel || exit 1
   source util/quickstart/setchplenv.bash
   export CHPL_REGEXP=re2
   make
@@ -27,22 +27,22 @@ checkPackage () {
   package=$(git diff --name-only HEAD HEAD~1)
   end=".end"
   path="$package$end"
-  cd $(dirname $path)
+  cd "$(dirname "$path")" || exit 1
   echo "package detected from git diff: ${package}"
   echo "package path: ${path}"
 
   # Parses the source from the toml
   FILE=$package
   basename "$FILE"
-  f="$(basename -- $FILE)"
+  f="$(basename -- "$FILE")"
   source="$(grep source "$f" | cut -d= -f2)"
 
   # Strips the quotes off of the source
   fixed=$(echo "$source" | tr -d '"')
 
   # Clones the source
-  git clone $fixed newPackage
-  cd newPackage
+  git clone "$fixed" newPackage
+  cd newPackage || exit 1
  }
 
 buildChapel
@@ -56,3 +56,4 @@ mason update
 
 mason publish --ci-check
 exit $?
+


### PR DESCRIPTION
This PR aims to shift the mason registry from the existing Travis CI to Github Actions. The packages submitted by an user would be tested and built using workflows and actions. There are 2 modes of workflows : - **pre-merge** workflow & **post-merge** workflow. 

- pre-merge workflow ( `masonRegCI.yaml` ) : This is triggered when a PR is made on the repository. This workflow is responsible for checking if a TOML file exists inside the packages in the Bricks directory. Additionally, Chapel is built and also a CI check is done in the package using `mason publish --ci-check`. 
- post-merge workflow ( `genCacheOnPush.yaml` ) : This is triggered once a PR is merged and a push is made on repository. This workflow is responsible for computing a score for the package based on quality and update the `cache.toml` file on repository. If a package with a certain version is already present in cache, then this script is aborted and cache is not updated. 

Additional post-merge changes to make : 
- [ ] change credentials to that of registry
- [ ] update cache file with computed values of already present packages
- [ ] improve `README `file to reflect new changes made and present guidelines for users. 