### PR TITLE
Update branch name for Chapel to main

### DIFF
--- a/util/travisScript.bash
+++ b/util/travisScript.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Clones master of chapel and quickstarts with CHPL_REGEXP=re2
-git clone --depth=1 --branch=master https://github.com/chapel-lang/chapel.git
+git clone --depth=1 --branch=main https://github.com/chapel-lang/chapel.git
 
 buildChapel () {
   cd chapel || exit 1


### PR DESCRIPTION
The mason scripts were still using `master` for the branch name, but Chapel has switched it's branch name to `main`.