### PR TITLE
Add CHPL_RE2=bundled to Chapel CI build command

### DIFF
--- a/util/travisScript.bash
+++ b/util/travisScript.bash
@@ -7,6 +7,7 @@ buildChapel () {
   cd chapel || exit 1
   source util/quickstart/setchplenv.bash
   export CHPL_REGEXP=re2
+  export CHPL_RE2=bundled
   make
  }
 


### PR DESCRIPTION
For mason to be built, `CHPL_RE2` must be set to `bundled`, so this adds that line to the Chapel build command.