### PR TITLE
Add SymArrayDmap mason package from Arkouda

### DIFF
--- a/Bricks/SymArrayDmap/0.1.0.toml
+++ b/Bricks/SymArrayDmap/0.1.0.toml
@@ -1,0 +1,10 @@
+[brick]
+authors="Mike Merrill"
+chplVersion="1.27.0"
+license="None"
+name="SymArrayDmap"
+source="https://github.com/bmcdonald3/SymArrayDmap"
+version="0.1.0"
+
+[dependencies]
+


### PR DESCRIPTION
This is the `SymArrayDmap` module from Arkouda and is the first Arkouda module to be ported to Mason.