### PR TITLE
 "Adding ForwardModeAD@0.1.0 package to registry via mason publish"

### DIFF
--- a/Bricks/ForwardModeAD/0.1.0.toml
+++ b/Bricks/ForwardModeAD/0.1.0.toml
@@ -4,7 +4,7 @@ authors = "Luca Ferranti"
 chplVersion = "1.28.0"
 license = "MIT"
 name = "ForwardModeAD"
-source = "https://github.com/lucaferranti/ForwardModeAD.git"
+source = "git@github.com:lucaferranti/ForwardModeAD.git"
 type = "library"
 version = "0.1.0"
 

--- a/Bricks/ForwardModeAD/0.1.0.toml
+++ b/Bricks/ForwardModeAD/0.1.0.toml
@@ -1,0 +1,12 @@
+
+[brick]
+authors = "Luca Ferranti"
+chplVersion = "1.28.0"
+license = "MIT"
+name = "ForwardModeAD"
+source = "git@github.com:lucaferranti/ForwardModeAD.git"
+type = "library"
+version = "0.1.0"
+
+[dependencies]
+

--- a/Bricks/ForwardModeAD/0.1.0.toml
+++ b/Bricks/ForwardModeAD/0.1.0.toml
@@ -4,7 +4,7 @@ authors = "Luca Ferranti"
 chplVersion = "1.28.0"
 license = "MIT"
 name = "ForwardModeAD"
-source = "git@github.com:lucaferranti/ForwardModeAD.git"
+source = "https://github.com/lucaferranti/ForwardModeAD.git"
 type = "library"
 version = "0.1.0"
 


### PR DESCRIPTION
A few questions

1. Should I create a tag release manually **before** having this merged? Should I have created it **before** running `mason publish`? (see also #62 )
2. How does mason find the right release? I would expect each release to be linked to a commit/tag, but I don't see related metadata in the toml-files. Is it so that if the version is `X.Y.Z`, then it looks for a tag `vX.Y.Z` from the given repository?
3. If in the future I want to update the package and bump the version, can I still do that via `mason publish`?