### PR TITLE
try workarounds for git ssh connection

### DIFF
--- a/.github/workflows/masonRegCI.yaml
+++ b/.github/workflows/masonRegCI.yaml
@@ -11,9 +11,14 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 3
+          persist-credentials false
       - name: Run checkTomlScript
         run: |
           bash ./checkTomls.bash
+      - name Reconfigure git to use HTTPS
+        run: >
+          git config --global url. "https://github.com/".insteadof
+          ssh://git@github.com/
       - name: CI Check package
         run: |
           bash ./util/runMasonCI.bash


### PR DESCRIPTION
This PR implements some attempts at fixing CI failures at the step
where we clone the user's submitted Mason package. 

In both ssh and https modes we are getting failures for new/updated packages.
For ssh connections, the failures look like 
```
 git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
```
and https gets a message that it's not allowed:
```
fatal: protocol ' https' is not supported
```

reviewed by @bmcdonald3 - thanks!