### PR TITLE
show CI variable values in output

### DIFF
--- a/util/runMasonCI.bash
+++ b/util/runMasonCI.bash
@@ -37,10 +37,10 @@ checkPackage () {
   basename "$FILE"
   f="$(basename -- "$FILE")"
   source="$(grep source "$f" | cut -d= -f2)"
-
+  echo $source
   # Strips the quotes off of the source
   fixed=$(echo "$source" | tr -d '"')
-
+  echo "$fixed"
   # Clones the source
   git clone "$fixed" newPackage
   cd newPackage || exit 1

--- a/util/runMasonCI.bash
+++ b/util/runMasonCI.bash
@@ -37,10 +37,10 @@ checkPackage () {
   basename "$FILE"
   f="$(basename -- "$FILE")"
   source="$(grep source "$f" | cut -d= -f2)"
-  echo $source
+  echo "source value: $source"
   # Strips the quotes off of the source
   fixed=$(echo "$source" | tr -d '"')
-  echo "$fixed"
+  echo "adjusted source to 'fixed' value: $fixed"
   # Clones the source
   git clone "$fixed" newPackage
   cd newPackage || exit 1


### PR DESCRIPTION
This PR adds printing of the values of some variables in the CI script to 
aid in troubleshooting recent failures.

reviewed by @riftEmber and @bmcdonald3 - thank you!