### PR TITLE
fix extra space in CI command

### DIFF
--- a/.github/workflows/masonRegCI.yaml
+++ b/.github/workflows/masonRegCI.yaml
@@ -17,7 +17,7 @@ jobs:
           bash ./checkTomls.bash
       - name: Reconfigure git to use HTTPS
         run: >
-          git config --global url. "https://github.com/".insteadof
+          git config --global url."https://github.com/".insteadof
           ssh://git@github.com/
       - name: CI Check package
         run: |


### PR DESCRIPTION
This PR fixes the git command I previously added that 
had a space in one argument... 