### PR TITLE
Trim whitespace before and after url in CI

### DIFF
--- a/util/runMasonCI.bash
+++ b/util/runMasonCI.bash
@@ -39,7 +39,7 @@ checkPackage () {
   source="$(grep source "$f" | cut -d= -f2)"
   echo "source value: $source"
   # Strips the quotes off of the source
-  fixed=$(echo "$source" | tr -d '"')
+  fixed=$(echo "$source" | tr -d '"' | awk '{$1=$1};1')
   echo "adjusted source to 'fixed' value: $fixed"
   # Clones the source
   git clone "$fixed" newPackage


### PR DESCRIPTION
The URL for the source code for mason packages might have a space before it and this caused errors like `fatal: protocol ' https' is not supported` because of the leading space when trying to clone the repo in our CI checks. This adds a simple step to trim the whitespace which will hopefully fix this failure.

Audrey MP ran into this with [this](https://github.com/chapel-lang/mason-registry/actions/runs/8850342427/job/24304413667?pr=71) PR and reported it on [Gitter](https://matrix.to/#/!PBYDSerrfYujeStENM:gitter.im/$u4AUsC9p9nzRiowd9hvC7OlP85qCwaXiHte5LJr6gds?via=gitter.im&via=matrix.org&via=gnome.org)