### PR TITLE
 "Adding ForwardModeAD@0.2.0 package to registry via mason publish"

### DIFF
--- a/Bricks/ForwardModeAD/0.2.0.toml
+++ b/Bricks/ForwardModeAD/0.2.0.toml
@@ -1,0 +1,12 @@
+
+[brick]
+authors = "Luca Ferranti"
+chplVersion = "2.0.0"
+license = "MIT"
+name = "ForwardModeAD"
+source = "git@github.com:lucaferranti/ForwardModeAD.git"
+type = "library"
+version = "0.2.0"
+
+[dependencies]
+


### PR DESCRIPTION
new release of ForwardModeAD to support chapel 2.0