### PR TITLE
Fix ci ssh authentication issue

### DIFF
--- a/.github/workflows/masonRegCI.yaml
+++ b/.github/workflows/masonRegCI.yaml
@@ -15,11 +15,6 @@ jobs:
       - name: Run checkTomlScript
         run: |
           bash ./checkTomls.bash
-      - name: Reconfigure git to use HTTPS
-        run: >
-          git config --global url."https://github.com/".insteadof
-          ssh://git@github.com/
       - name: CI Check package
         run: |
           bash ./util/runMasonCI.bash
-

--- a/.github/workflows/masonRegCI.yaml
+++ b/.github/workflows/masonRegCI.yaml
@@ -1,8 +1,8 @@
 name: Mason Registry CI
 on:
   pull_request:
-    paths:
-      - 'Bricks/**'
+    # paths:
+    #   - 'Bricks/**'
 jobs:
   checks_for_package:
     name: Check Package

--- a/.github/workflows/masonRegCI.yaml
+++ b/.github/workflows/masonRegCI.yaml
@@ -15,6 +15,10 @@ jobs:
       - name: Run checkTomlScript
         run: |
           bash ./checkTomls.bash
+      - name: Reconfigure git to use HTTPS
+        run: |
+          git config --global url."https://github.com/".insteadOf git@github.com:
+          git config --global url."https://".insteadOf git://
       - name: CI Check package
         run: |
           bash ./util/runMasonCI.bash

--- a/Bricks/_MasonTest1/0.2.0.toml
+++ b/Bricks/_MasonTest1/0.2.0.toml
@@ -5,6 +5,5 @@ version = "0.2.0"
 chplVersion = "1.16.0"
 author = "Sam Partee"
 source = "https://github.com/Spartee/_MasonTest1"
-x = ""
 
 [dependencies]

--- a/Bricks/_MasonTest1/0.2.0.toml
+++ b/Bricks/_MasonTest1/0.2.0.toml
@@ -2,7 +2,7 @@
 [brick]
 name = "_MasonTest1"
 version = "0.2.0"
-chplVersion = "1.17.0"
+chplVersion = "1.16.0"
 author = "Sam Partee"
 source = "https://github.com/Spartee/_MasonTest1"
 

--- a/Bricks/_MasonTest1/0.2.0.toml
+++ b/Bricks/_MasonTest1/0.2.0.toml
@@ -2,7 +2,7 @@
 [brick]
 name = "_MasonTest1"
 version = "0.2.0"
-chplVersion = "1.16.0"
+chplVersion = "1.17.0"
 author = "Sam Partee"
 source = "https://github.com/Spartee/_MasonTest1"
 

--- a/Bricks/_MasonTest1/0.2.0.toml
+++ b/Bricks/_MasonTest1/0.2.0.toml
@@ -5,5 +5,6 @@ version = "0.2.0"
 chplVersion = "1.16.0"
 author = "Sam Partee"
 source = "https://github.com/Spartee/_MasonTest1"
+x = ""
 
 [dependencies]

--- a/util/runMasonCI.bash
+++ b/util/runMasonCI.bash
@@ -9,6 +9,7 @@ buildChapel () {
   # export CHPL_REGEXP=re2
   # export CHPL_RE2=bundled
   # make
+  echo "yep"
  }
 
 # Runs a make check, and if it passes then makes mason
@@ -20,6 +21,7 @@ makeCheckAndMason () {
   # else
   #   exit 1
   # fi
+  echo "yep"
  }
 
 # Parses the last merge commit, getting the most recent package added to the registry

--- a/util/runMasonCI.bash
+++ b/util/runMasonCI.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Clones master of chapel and quickstarts with CHPL_REGEXP=re2
-git clone --depth=1 --branch=main git@github.com:chapel-lang/chapel.git
+git clone --depth=1 --branch=main https://github.com/chapel-lang/chapel.git
 
 buildChapel () {
   cd chapel || exit 1

--- a/util/runMasonCI.bash
+++ b/util/runMasonCI.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Clones master of chapel and quickstarts with CHPL_REGEXP=re2
-git clone --depth=1 --branch=main https://github.com/chapel-lang/chapel.git
+git clone --depth=1 --branch=main git@github.com:chapel-lang/chapel.git
 
 buildChapel () {
   cd chapel || exit 1
@@ -57,4 +57,3 @@ mason update
 
 mason publish --ci-check
 exit $?
-

--- a/util/runMasonCI.bash
+++ b/util/runMasonCI.bash
@@ -4,22 +4,22 @@
 git clone --depth=1 --branch=main https://github.com/chapel-lang/chapel.git
 
 buildChapel () {
-  cd chapel || exit 1
-  source util/quickstart/setchplenv.bash
-  export CHPL_REGEXP=re2
-  export CHPL_RE2=bundled
-  make
+  # cd chapel || exit 1
+  # source util/quickstart/setchplenv.bash
+  # export CHPL_REGEXP=re2
+  # export CHPL_RE2=bundled
+  # make
  }
 
 # Runs a make check, and if it passes then makes mason
 makeCheckAndMason () {
-  make check
-  output=$?
-  if [ ${output} -eq 0 ]; then
-    make mason
-  else
-    exit 1
-  fi
+  # make check
+  # output=$?
+  # if [ ${output} -eq 0 ]; then
+  #   make mason
+  # else
+  #   exit 1
+  # fi
  }
 
 # Parses the last merge commit, getting the most recent package added to the registry
@@ -28,6 +28,7 @@ checkPackage () {
   package=$(git diff --name-only HEAD HEAD~1)
   end=".end"
   path="$package$end"
+  echo $path
   cd "$(dirname "$path")" || exit 1
   echo "package detected from git diff: ${package}"
   echo "package path: ${path}"


### PR DESCRIPTION
Fix CI issue where the runner is unable to clone the users repo:
```
adjusted source to 'fixed' value: git@github.com:lucaferranti/ForwardModeAD.git
Cloning into 'newPackage'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```