### PR TITLE
Fix the CI since HEAD is not accesible

### DIFF
--- a/.github/workflows/masonRegCI.yaml
+++ b/.github/workflows/masonRegCI.yaml
@@ -4,19 +4,43 @@ on:
     paths:
       - 'Bricks/**'
 jobs:
+  find_package:
+    name: Find package to run CI on
+    runs-on: ubuntu-latest
+    outputs:
+      package_path: ${{ steps.find_pkg.outputs.package_path }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 3
+          persist-credentials: false
+      - name: Find the last modified package
+        id: find_pkg
+        run: |
+          # Parses the last merge commit, getting the most recent package added to the registry
+          echo "Finding the last modified package in Bricks directory..."
+          LAST_MODIFIED_PACKAGE=$(git diff --name-only HEAD~1 HEAD | grep -E '.*\.toml' | head -n 1)
+          if [ -z "$LAST_MODIFIED_PACKAGE" ]; then
+            echo "No package found in the last commit. Exiting."
+            exit 0
+          fi
+          echo "Last modified package: $LAST_MODIFIED_PACKAGE"
+          echo "package_path=$LAST_MODIFIED_PACKAGE" >> $GITHUB_OUTPUT
   checks_for_package:
     name: Check Package
+    needs: find_package
     runs-on: ubuntu-latest
     container:
       image: chapel/chapel:latest
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 3
           persist-credentials: false
       - name: Run checkTomlScript
         run: |
           bash ./util/checkTomls.bash
       - name: CI Check package
         run: |
-          bash ./util/runMasonCI.bash
+          package_toml=${{ needs.find_package.outputs.package_path }}
+          echo "Running CI checks for package: $package_toml"
+          bash ./util/runMasonCI.bash "$package_toml"

--- a/util/runMasonCI.bash
+++ b/util/runMasonCI.bash
@@ -1,20 +1,21 @@
 #!/usr/bin/env bash
 
 
-# Parses the last merge commit, getting the most recent package added to the registry
 checkPackage () {
-  package=$(git diff --name-only HEAD HEAD~1 | grep -E '.*\.toml')
-  end=".end"
-  path="$package$end"
-  cd "$(dirname "$path")" || exit 1
+  package=$1
+  if [ -z "$package" ]; then
+    echo "No package path provided. Exiting."
+    exit 1
+  fi
+  if [ ! -f "$package" ]; then
+    echo "Provided package path does not exist: $package. Exiting."
+    exit 1
+  fi
   echo "package detected from git diff: ${package}"
   echo "package path: ${path}"
 
   # Parses the source from the toml
-  FILE=$package
-  basename "$FILE"
-  f="$(basename -- "$FILE")"
-  source="$(grep source "$f" | cut -d= -f2)"
+  source="$(grep source "$package" | cut -d= -f2)"
   echo "source value: $source"
   # Strips the quotes off of the source
   fixed=$(echo "$source" | tr -d '"' | awk '{$1=$1};1')
@@ -25,7 +26,7 @@ checkPackage () {
   cd newPackage || exit 1
 }
 
-checkPackage
+checkPackage "$1"
 
 # adds mason-registry to MASON_HOME
 mason update


### PR DESCRIPTION
Fixes the CI after https://github.com/chapel-lang/mason-registry/pull/82.

It seems `HEAD` is not useable when using `container.image` in a job. I don't know why this is, but I do know GHA can have weird differing behaviors when `container.image` is used.

To work around this, a job is used to compute the file to check without a container, then that file is passed to the job with a container