### PR TITLE
Fix Log 0.1.0 to only allow 2.9+

### DIFF
--- a/Bricks/Log/0.1.0.toml
+++ b/Bricks/Log/0.1.0.toml
@@ -1,7 +1,7 @@
 [brick]
 name = "Log"
 version = "0.1.0"
-chplVersion = "2.8.0"
+chplVersion = "2.9.0"
 type = "library"
 source = "git@github.com:jabraham17/Log.git"
 authors = ["Jade Abraham"]


### PR DESCRIPTION
Fixes the TOML for Log 0.1.0 to only allow 2.9+