### PR TITLE
Create an index file in the repository

### DIFF
--- a/.github/workflows/generate_index.yaml
+++ b/.github/workflows/generate_index.yaml
@@ -1,0 +1,45 @@
+name: Generate Registry Index
+
+on:
+  push:
+    branches:
+      - master
+
+# Serialize runs so two pushes don't produce conflicting index.json commits.
+# cancel-in-progress: false ensures each queued run still finishes.
+concurrency:
+  group: generate-registry-index
+  cancel-in-progress: false
+
+# Skip if the push came from the bot itself, to avoid an infinite trigger loop.
+jobs:
+  generate:
+    name: Generate index.json
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Generate index.json
+        run: python3 util/generate_registry_index.py
+
+      - name: Commit and push index.json
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add index.json
+          if git diff --cached --quiet; then
+            echo "index.json is already up to date, nothing to commit."
+          else
+            git commit -m "regenerate index.json"
+            git push
+          fi

--- a/.github/workflows/generate_index.yaml
+++ b/.github/workflows/generate_index.yaml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: true
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/generate_index.yaml
+++ b/.github/workflows/generate_index.yaml
@@ -27,8 +27,6 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
 
       - name: Generate index.json
         run: python3 util/generate_registry_index.py

--- a/util/generate_registry_index.py
+++ b/util/generate_registry_index.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Generate a JSON index of all packages in the Mason registry.
+
+Reads every Bricks/<Package>/<X.Y.Z>.toml file and writes index.json at the
+repo root with the shape:
+
+    { [package: string]: Version[] }
+
+where each Version contains the fields present in the [brick] table:
+version, chplVersion, authors, license, source, copyrightYear.
+Keys are omitted when not present in the TOML file.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ImportError:
+    try:
+        import tomli as tomllib  # type: ignore[no-redef]
+    except ImportError:
+        print(
+            "Error: tomllib (Python 3.11+) or the 'tomli' package is required.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+REPO_ROOT = Path(__file__).parent.parent
+BRICKS_DIR = REPO_ROOT / "Bricks"
+OUTPUT_FILE = REPO_ROOT / "index.json"
+
+OPTIONAL_KEYS = ("chplVersion", "authors", "license", "source", "copyrightYear", "type")
+
+
+def semver_key(toml_path: Path) -> tuple[int, ...]:
+    """Return an (X, Y, Z) tuple for semver-correct sorting of version filenames."""
+    parts = toml_path.stem.split(".")
+    try:
+        return tuple(-int(p) for p in parts)
+    except ValueError:
+        return (0, 0, 0)
+
+
+def normalize_authors(value: str | list[str]) -> list[str]:
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def git_creation_date(path: Path) -> str | None:
+    """Return the ISO 8601 date when the file was first committed, or None."""
+    result = subprocess.run(
+        [
+            "git", "--no-pager", "log",
+            "--follow", "--diff-filter=A", "--format=%aI",
+            "--", str(path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    date = result.stdout.strip()
+    return date if date else None
+
+
+def build_index() -> dict[str, list[dict]]:
+    index: dict[str, list[dict]] = {}
+
+    for pkg_dir in sorted(BRICKS_DIR.iterdir(), key=lambda x: str(x).lower()):
+        if not pkg_dir.is_dir():
+            continue
+
+        if pkg_dir.name in ("_MasonTest1", "_MasonTest2"):
+            continue
+
+        versions: list[dict] = []
+        for toml_file in sorted(pkg_dir.glob("*.toml"), key=semver_key):
+            with open(toml_file, "rb") as f:
+                data = tomllib.load(f)
+
+            brick = data.get("brick", {})
+            declared = brick.get("version")
+            if declared != toml_file.stem:
+                print(
+                    f"Error: {toml_file}: filename '{toml_file.stem}' does not match "
+                    f"declared version '{declared}'",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            entry: dict = {"version": declared}
+
+            created = git_creation_date(toml_file)
+            if created is not None:
+                entry["createdDate"] = created
+
+            for key in OPTIONAL_KEYS:
+                if key in brick:
+                    value = brick[key]
+                    if key == "authors":
+                        value = normalize_authors(value)
+                    entry[key] = value
+
+            versions.append(entry)
+
+        if versions:
+            index[pkg_dir.name] = versions
+
+    return index
+
+
+def main() -> None:
+    index = build_index()
+    with open(OUTPUT_FILE, "w", encoding="utf-8") as f:
+        json.dump(index, f, indent=2)
+        f.write("\n")
+    print(f"Wrote {OUTPUT_FILE} ({len(index)} packages)")
+
+
+if __name__ == "__main__":
+    main()

--- a/util/generate_registry_index.py
+++ b/util/generate_registry_index.py
@@ -15,18 +15,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
-
-try:
-    import tomllib
-except ImportError:
-    try:
-        import tomli as tomllib  # type: ignore[no-redef]
-    except ImportError:
-        print(
-            "Error: tomllib (Python 3.11+) or the 'tomli' package is required.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+import tomllib
 
 REPO_ROOT = Path(__file__).parent.parent
 BRICKS_DIR = REPO_ROOT / "Bricks"
@@ -72,7 +61,7 @@ def build_index() -> dict[str, list[dict]]:
         if not pkg_dir.is_dir():
             continue
 
-        if pkg_dir.name in ("_MasonTest1", "_MasonTest2"):
+        if pkg_dir.name.startswith("_"):
             continue
 
         versions: list[dict] = []


### PR DESCRIPTION
This PR exists to enable Mason package browsing and search, drawing from the registry.

## Design

To ensure that new packages added to the repo quickly appeared when browsed (the package viewer/browseer here is a separate piece of the puzzle and is not included in this PR), @jabraham17 and I saw two main design routes:

* **Use Hugo and [the site repo](https://github.com/chapel-lang/chapel-www) to generate the list statically.** This is appealing because of Hugo's rich templating power and ability to read data (including data hosted elsewhere). The "quick update" would be achieved by having an auto-opened PR against the site repo which includes changes to the displayed list, which is then merged.
* **Dynamically load a list of packages from this repo**. Because the current representation has 1 file per package version, this can't be done naively in a scalable way. Instead, in a similar fashion to the Hugo approach above, we can auto-generate changes to a single combined index file and PR them against this repo when a new package is merged. This single file can then be loaded by client-side JavaScript.

Because we currently do not support automatic deployment, the first approach would be somewhat slower and require some manual intervention out-of-band from regular registry updates. Thus, we opted for the second approach, with one small tweak: we can auto-commit the generated file right away, without having to go through a second PR or approval.

## Implementation

This is implemented in this PR: a new Python script that, on commit, generates a single `.json` file (JSON having been chosen for easy consumption by JavaScript-based web clients) that includes the package versions present in this repository. This Python script is executed by a GitHub action that runs the script on commit, and makes a _new_ commit with the updated index[^1].

Right now, this script also draws a 'create date' from the Git history of the repository, to give an indication of when a package was published.

I've tested this against my personal repo. The generated commit is https://github.com/DanilaFe/mason-registry/commit/ffd492b9b025f8c04c4b9bf95f177d4adef9c8b9, and I was successfully able to pull the JSON file for the Mason registry from GitHub and render a live viewer.

[^1]: You're right to notice the circular dependency; `if: github.actor != 'github-actions[bot]'` is there to avoid infinite regenerations.

Reviewed by @jabraham17 -- thanks!