### PR TITLE
Adjust index generation to work with branch protections

### DIFF
--- a/.github/workflows/generate_index.yaml
+++ b/.github/workflows/generate_index.yaml
@@ -32,20 +32,15 @@ jobs:
       - name: Generate index.json
         run: python3 util/generate_registry_index.py
 
-      - name: Open index-update PR
-        env:
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
-          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+      - name: Prepare index branch
+        id: prep
         run: |
           git config user.name  "chapelautomaton"
           git config user.email "chapelautomaton@users.noreply.github.com"
 
-          # Explicitly embed the token in the remote URL so git push
-          # uses BOT_TOKEN regardless of the default credential helper.
-          git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${{ github.repository }}.git"
-
           if git diff --quiet index.json; then
             echo "index.json is already up to date, nothing to do."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -53,11 +48,26 @@ jobs:
           git checkout -b "$BRANCH"
           git add index.json
           git commit -m "regenerate index.json"
-          git push origin "$BRANCH"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
+      - name: Push index branch
+        if: steps.prep.outputs.changed == 'true'
+        uses: ad-m/github-push-action@v1
+        with:
+          github_token: ${{ secrets.BOT_TOKEN }}
+          repository: ${{ github.repository }}
+          branch: ${{ steps.prep.outputs.branch }}
+
+      - name: Open and auto-merge PR
+        if: steps.prep.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+        run: |
           PR_URL=$(gh pr create \
+            --repo "${{ github.repository }}" \
             --base master \
-            --head "$BRANCH" \
+            --head "${{ steps.prep.outputs.branch }}" \
             --title "regenerate index.json" \
             --body "Automated index regeneration triggered by merge of #${{ github.event.pull_request.number }}.")
 

--- a/.github/workflows/generate_index.yaml
+++ b/.github/workflows/generate_index.yaml
@@ -71,4 +71,18 @@ jobs:
             --title "regenerate index.json" \
             --body "Automated index regeneration triggered by merge of #${{ github.event.pull_request.number }}.")
 
-          gh pr merge --auto --merge "$PR_URL"
+          # Wait for GitHub to register checks on the new PR before enabling
+          # auto-merge, to avoid the "pull request is in clean status" race.
+          echo "Waiting for checks to be registered on $PR_URL ..."
+          for i in $(seq 1 20); do
+            CHECK_COUNT=$(gh pr checks "$PR_URL" 2>/dev/null | wc -l)
+            if [ "$CHECK_COUNT" -gt 0 ]; then
+              echo "Checks registered ($CHECK_COUNT), enabling auto-merge."
+              gh pr merge --auto --merge "$PR_URL"
+              exit 0
+            fi
+            echo "No checks yet (attempt $i/20), retrying in 10s..."
+            sleep 10
+          done
+
+          echo "No checks triggered. PR will need to be merged manually."

--- a/.github/workflows/generate_index.yaml
+++ b/.github/workflows/generate_index.yaml
@@ -35,9 +35,14 @@ jobs:
       - name: Open index-update PR
         env:
           GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
           git config user.name  "chapelautomaton"
           git config user.email "chapelautomaton@users.noreply.github.com"
+
+          # Explicitly embed the token in the remote URL so git push
+          # uses BOT_TOKEN regardless of the default credential helper.
+          git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${{ github.repository }}.git"
 
           if git diff --quiet index.json; then
             echo "index.json is already up to date, nothing to do."

--- a/.github/workflows/validate_index.yaml
+++ b/.github/workflows/validate_index.yaml
@@ -1,0 +1,16 @@
+name: Validate Registry Index
+
+on:
+  pull_request:
+    paths:
+      - 'index.json'
+
+jobs:
+  validate:
+    name: Validate index.json
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate index.json with jq
+        run: jq '.' index.json > /dev/null


### PR DESCRIPTION
Co-authored with @jabraham17.

This PR implements some changes to our initial index generation mechanism. The original approach (of just commiting the index file on merge) is a violation of branch protection rules, since the GitHub actions but directly writes to `master`. Instead, adjust the CI actions to generate a pull request and merge it automatically.

To enable automatic merging, we need the affected files (`index.json`) to have at least one CI check. To start with, simply feed the index into `jq` to validate that it's well-formed.

This will require a `BOT_TOKEN` secret that has write access to the repository and is able to merge PRs.